### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "EPEX Spot AT",
     "Strompreis"
   ],
+  "engines": {
+    "node": ">=16"
+  },
   "dependencies": {
     "@esm2cjs/is-online": "^10.0.0",
     "@iobroker/adapter-core": "^3.0.3",


### PR DESCRIPTION
adapter-core 3.x.x is known to fail when installing at node 14 due to npm 7 not installing peerDependencies. So this adapter requires node 16 or newer.